### PR TITLE
Attempt to relax dependency requirements on PyWavelets

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
         'torchvision',
         'numpy==1.*',
         'pytorch_wavelets @ git+https://github.com/fbcotter/pytorch_wavelets',
-        'PyWavelets~=1.3',
+        'PyWavelets',
         'open_clip_torch~=2.7'
     ],
     include_package_data=True,


### PR DESCRIPTION
Just FYI. `rudalle` insists on installing an old version of `PyWavelets`, and this prevents a clean install when using both projects (like in [the sampling notebook](https://github.com/dome272/Paella/blob/main/ongoing_research/scaling/paella_sampling.ipynb)).

Another solution would be to extract the VAE code from `rudalle`, since I think that's the only portion that's being used for Paella.